### PR TITLE
Configure `robots.txt` through an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # natural-capital-primer
 A science-based resource that explains the concept of natural capital and how business and society depend on it.
+
+## Install & run
+
+### Environment variables
+
+See [src/env.mjs](https://github.com/Vizzuality/natural-capital-primer/tree/develop/src/env.mjs).

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-tabs": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.2",
+        "@t3-oss/env-nextjs": "^0.11.1",
         "@uidotdev/usehooks": "^2.4.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -28,7 +29,8 @@
         "react-dom": "^18",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
-        "typescript-eslint": "^7.13.1"
+        "typescript-eslint": "^7.13.1",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@svgr/webpack": "^8.1.0",
@@ -3387,6 +3389,37 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@t3-oss/env-core": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@t3-oss/env-core/-/env-core-0.11.1.tgz",
+      "integrity": "sha512-MaxOwEoG1ntCFoKJsS7nqwgcxLW1SJw238AJwfJeaz3P/8GtkxXZsPPolsz1AdYvUTbe3XvqZ/VCdfjt+3zmKw==",
+      "peerDependencies": {
+        "typescript": ">=5.0.0",
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@t3-oss/env-nextjs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@t3-oss/env-nextjs/-/env-nextjs-0.11.1.tgz",
+      "integrity": "sha512-rx2XL9+v6wtOqLNJbD5eD8OezKlQD1BtC0WvvtHwBgK66jnF5+wGqtgkKK4Ygie1LVmoDClths2T4tdFmRvGrQ==",
+      "dependencies": {
+        "@t3-oss/env-core": "0.11.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0",
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@trysound/sax": {
@@ -9101,6 +9134,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
+    "@t3-oss/env-nextjs": "^0.11.1",
     "@uidotdev/usehooks": "^2.4.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
@@ -30,7 +31,8 @@
     "react-dom": "^18",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
-    "typescript-eslint": "^7.13.1"
+    "typescript-eslint": "^7.13.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+import { env } from "@/env.mjs";
+
+export default function robots(): MetadataRoute.Robots {
+  if (env.NEXT_USE_RESTRICTIVE_ROBOTS_TXT) {
+    return {
+      rules: {
+        userAgent: "*",
+        disallow: "/",
+      },
+    };
+  }
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+  };
+}

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -1,0 +1,32 @@
+import { createEnv } from "@t3-oss/env-nextjs";
+import { z } from "zod";
+
+export const env = createEnv({
+  /*
+   * Serverside Environment variables, not available on the client.
+   * Will throw if you access these variables on the client.
+   */
+  server: {},
+  /*
+   * Environment variables available on the client (and server).
+   *
+   * 💡 You'll get type errors if these are not prefixed with NEXT_PUBLIC_.
+   */
+  client: {
+    // If `true` or left empty, crawlers (including search engines) are not allowed to index the
+    // website
+    NEXT_USE_RESTRICTIVE_ROBOTS_TXT: z.preprocess(
+      (value) => (!value || value === "true" ? true : false),
+      z.boolean(),
+    ),
+  },
+  /*
+   * Due to how Next.js bundles environment variables on Edge and Client,
+   * we need to manually destructure them to make sure all are included in bundle.
+   *
+   * 💡 You'll get type errors if not all variables from `server` & `client` are included here.
+   */
+  runtimeEnv: {
+    NEXT_USE_RESTRICTIVE_ROBOTS_TXT: process.env.NEXT_USE_RESTRICTIVE_ROBOTS_TXT,
+  },
+});


### PR DESCRIPTION
This PR allows to configure, through the `NEXT_USE_RESTRICTIVE_ROBOTS_TXT` environment variable, if the website can be crawled or not. By default, the website can't be crawled.

## Tracking

[NCP-41](https://vizzuality.atlassian.net/browse/NCP-41).

[NCP-41]: https://vizzuality.atlassian.net/browse/NCP-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ