### PR TITLE
Switch case studies pages to server side pages, remove fetch data from layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-tabs": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@t3-oss/env-nextjs": "^0.11.1",
+    "@tanstack/react-query": "^5.81.2",
     "@uidotdev/usehooks": "^2.4.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@t3-oss/env-nextjs':
         specifier: ^0.11.1
         version: 0.11.1(typescript@5.8.3)(zod@3.25.56)
+      '@tanstack/react-query':
+        specifier: ^5.81.2
+        version: 5.81.2(react@19.1.0)
       '@uidotdev/usehooks':
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2674,6 +2677,14 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@tanstack/query-core@5.81.2':
+    resolution: {integrity: sha512-QLYkPdrudoMATDFa3MiLEwRhNnAlzHWDf0LKaXUqJd0/+QxN8uTPi7bahRlxoAyH0UbLMBdeDbYzWALj7THOtw==}
+
+  '@tanstack/react-query@5.81.2':
+    resolution: {integrity: sha512-pe8kFlTrL2zFLlcAj2kZk9UaYYHDk9/1hg9EBaoO3cxDhOZf1FRGJeziSXKrVZyxIfs7b3aoOj/bw7Lie0mDUg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
@@ -8963,6 +8974,13 @@ snapshots:
       zod: 3.25.56
     optionalDependencies:
       typescript: 5.8.3
+
+  '@tanstack/query-core@5.81.2': {}
+
+  '@tanstack/react-query@5.81.2(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.81.2
+      react: 19.1.0
 
   '@tokenizer/token@0.3.0': {}
 

--- a/src/app/(frontend)/case-studies/[slug]/page.tsx
+++ b/src/app/(frontend)/case-studies/[slug]/page.tsx
@@ -13,15 +13,7 @@ import { notFound } from "next/navigation";
 import { Metadata } from "next";
 import { getCaseStudies, getCaseStudy } from "@/cms/service/case-studies";
 import { extractTextFromCaseStudyIntroduction } from "./utils";
-import { getAppSettings } from "@/cms/service/app-settings";
-
-export async function generateStaticParams() {
-  const caseStudies = await getCaseStudies();
-
-  return caseStudies.map((cs) => ({
-    slug: cs.id,
-  }));
-}
+import { env } from "@/env.mjs";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -46,9 +38,7 @@ const CaseStudiesPage = async ({ params }: { params: Promise<{ slug: string }> }
 
   const caseStudies = await getCaseStudies();
 
-  const enableCaseStudies = await getAppSettings().then(
-    (settings) => settings?.enableCaseStudies === "true",
-  );
+  const enableCaseStudies = env.NEXT_PUBLIC_ENABLE_CASE_STUDIES === "true";
 
   if (!caseStudy || !enableCaseStudies) {
     notFound();

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -7,8 +7,6 @@ import Analytics from "@/components/analytics";
 import PrivacyBanner from "@/components/privacy-banner";
 import { env } from "@/env.mjs";
 import Header from "@/components/header";
-import { getCaseStudies } from "@/cms/service/case-studies";
-import { getAppSettings } from "@/cms/service/app-settings";
 
 const circular = localFont({
   src: [
@@ -45,14 +43,12 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const caseStudies = await getCaseStudies();
-  const appSettings = await getAppSettings();
   return (
     <html lang="en" className={cn("overflow-x-clip scroll-smooth", circular.className)}>
       <body className="overflow-x-clip bg-white text-black">
         <Providers>
           <PrivacyBanner />
-          <Header appSettings={appSettings} caseStudies={caseStudies} />
+          <Header />
           {children}
           <Analytics />
         </Providers>

--- a/src/app/(frontend)/query-provider.tsx
+++ b/src/app/(frontend)/query-provider.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { isServer, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        // With SSR, we usually want to set some default staleTime above 0 to avoid refetching
+        // immediately on the client
+        staleTime: 60 * 1000,
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+function getQueryClient() {
+  if (isServer) {
+    // Server: always make a new query client
+    return makeQueryClient();
+  } else {
+    // Browser: make a new query client if we don't already have one
+    // This is very important, so we don't re-make a new client if React
+    // suspends during the initial render. This may not be needed if we
+    // have a suspense boundary BELOW the creation of the query client
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}
+
+export default function QueryProvider({ children }: { children: React.ReactNode }) {
+  // NOTE: Avoid useState when initializing the query client if you don't
+  //       have a suspense boundary between this and the code that may
+  //       suspend because React will throw away the client on the initial
+  //       render if it suspends and there is no boundary
+  const queryClient = getQueryClient();
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,12 +1,18 @@
-import { getCaseStudies } from "@/cms/service/case-studies";
+// import { getCaseStudies } from "@/cms/service/case-studies";
 import { env } from "@/env.mjs";
+import { getCaseStudies } from "@/hooks/use-case-studies";
 import type { MetadataRoute } from "next";
+
+// This variable makes sure the sitemap is not statically generated
+// This is especially important as when the app is build, there is no access to the CMS
+export const dynamic = "force-dynamic";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseURL = `https://${env.NEXT_PUBLIC_DOMAIN}`;
 
   const caseStudies = await getCaseStudies();
-  const caseStudiesSitemap = caseStudies.map((caseStudy) => ({
+
+  const caseStudiesSitemap = caseStudies?.docs?.map((caseStudy) => ({
     url: `${baseURL}/case-studies/${caseStudy.id}`,
     priority: 0.5,
   }));

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -36,7 +36,8 @@ import {
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
 import useMediaQuery from "@/hooks/use-media-query";
-import { AppSetting, CaseStudy } from "@/payload-types";
+import useGetCaseStudies from "@/hooks/use-case-studies";
+import { env } from "@/env.mjs";
 
 const DIALOG_ANIMATION_DURATION = 0.3;
 const HEADER_ANIMATION_DURATION = 0.3;
@@ -46,13 +47,12 @@ const HEADER_VARIANTS = {
   hidden: { y: "-53px" },
 };
 
-type HeaderProps = {
-  caseStudies?: CaseStudy[];
-  appSettings?: AppSetting | null;
-};
-const Header = ({ caseStudies, appSettings }: HeaderProps) => {
+const Header = () => {
   const [visible, setVisible] = useState(true);
   const [open, setOpen] = useState(false);
+
+  const { data: caseStudiesData } = useGetCaseStudies();
+  const isCaseStudiesActive = env.NEXT_PUBLIC_ENABLE_CASE_STUDIES === "true";
   // The following state is only used by the desktop navigation (outside of the modal). The value is modified depending
   // on how the user interacts with the menu items (mouse, touch, etc.).
   const [displayIntroductionSubSections, setDisplayIntroductionSubSections] = useState(false);
@@ -189,8 +189,6 @@ const Header = ({ caseStudies, appSettings }: HeaderProps) => {
     [pathname, router],
   );
 
-  const isCaseStudiesActive = appSettings?.enableCaseStudies === "true";
-
   return (
     <motion.header
       className="sticky top-0 z-50 border-b border-b-black bg-white"
@@ -289,7 +287,7 @@ const Header = ({ caseStudies, appSettings }: HeaderProps) => {
                     Case Studies
                   </NavigationMenuTrigger>
                   <NavigationMenuContent className="flex flex-col gap-3">
-                    {caseStudies?.map((caseStudy) => (
+                    {caseStudiesData?.docs?.map((caseStudy) => (
                       <NavigationMenuLink
                         key={caseStudy.id}
                         className={navigationMenuTriggerStyle()}
@@ -539,7 +537,7 @@ const Header = ({ caseStudies, appSettings }: HeaderProps) => {
                                           </MobileOnlyAccordionTrigger>
                                           <MobileOnlyAccordionContent variant="naked">
                                             <ul className="flex flex-col gap-2 pt-3 text-base font-normal">
-                                              {caseStudies?.map((caseStudy) => (
+                                              {caseStudiesData?.docs?.map((caseStudy) => (
                                                 <li key={caseStudy.id}>
                                                   <Link
                                                     onClick={() => setOpen(false)}

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,7 +1,12 @@
 import { PropsWithChildren } from "react";
-import { Provider } from "jotai";
+import { Provider as JotaiProvider } from "jotai";
 import { store } from "@/lib/store";
+import QueryProvider from "@/app/(frontend)/query-provider";
 
 export const Providers = ({ children }: PropsWithChildren) => {
-  return <Provider store={store}>{children}</Provider>;
+  return (
+    <QueryProvider>
+      <JotaiProvider store={store}>{children}</JotaiProvider>
+    </QueryProvider>
+  );
 };

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -33,6 +33,8 @@ export const env = createEnv({
     NEXT_PUBLIC_GA_TRACKING_ID: z.string().optional(),
     // The Google Tag Manager tracking id
     NEXT_PUBLIC_GTM_TRACKING_ID: z.string().optional(),
+    // Enable case studies on the menu navigation and case studies pages
+    NEXT_PUBLIC_ENABLE_CASE_STUDIES: z.string().default("false"),
   },
   /*
    * Due to how Next.js bundles environment variables on Edge and Client,
@@ -52,5 +54,6 @@ export const env = createEnv({
     S3_REGION: process.env.S3_REGION,
     EMAIL_RESEND_API_KEY: process.env.EMAIL_RESEND_API_KEY,
     EMAIL_DEFAULT_FROM_ADRESS: process.env.EMAIL_DEFAULT_FROM_ADRESS,
+    NEXT_PUBLIC_ENABLE_CASE_STUDIES: process.env.NEXT_PUBLIC_ENABLE_CASE_STUDIES,
   },
 });

--- a/src/hooks/use-case-studies.ts
+++ b/src/hooks/use-case-studies.ts
@@ -1,0 +1,36 @@
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+
+import { CaseStudy } from "@/payload-types";
+
+type CaseStudyResponse = {
+  docs: CaseStudy[];
+};
+
+export async function getCaseStudies(): Promise<CaseStudyResponse> {
+  try {
+    const params = new URLSearchParams({
+      limit: "100", // Adjust limit as needed
+    });
+    const queryString = params.toString();
+    const response = await fetch(`/api/case-studies?${queryString}`);
+    if (!response.ok) {
+      throw new Error(response.statusText);
+    }
+    return response.json();
+  } catch (error) {
+    console.error("Error fetching case studies:", error);
+    throw error;
+  }
+}
+
+export const caseStudiesQueryKey = ["case-studies"];
+
+export default function useGetCaseStudies(
+  useQueryOptions?: Omit<UseQueryOptions<CaseStudyResponse, Error>, "queryKey" | "queryFn">,
+) {
+  return useQuery<CaseStudyResponse, Error>({
+    queryKey: caseStudiesQueryKey,
+    queryFn: () => getCaseStudies(),
+    ...useQueryOptions,
+  });
+}

--- a/src/hooks/use-case-study.ts
+++ b/src/hooks/use-case-study.ts
@@ -1,0 +1,24 @@
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+
+import { CaseStudy } from "@/payload-types";
+
+export async function getCaseStudy(id: CaseStudy["id"]) {
+  const response = await fetch(`/api/caseStudies/${id}`);
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+  return response.json();
+}
+
+export const getCaseStudyQueryKey = (id: string) => ["case-study", id];
+
+export default function useGetCaseStudy<T>(
+  id: CaseStudy["id"],
+  useQueryOptions?: Omit<UseQueryOptions<CaseStudy, Error, T>, "queryKey" | "queryFn">,
+) {
+  return useQuery<CaseStudy, Error, T>({
+    queryKey: getCaseStudyQueryKey(id),
+    queryFn: () => getCaseStudy(id),
+    ...useQueryOptions,
+  });
+}


### PR DESCRIPTION

This pull request introduces significant updates to the codebase, primarily focusing on integrating `@tanstack/react-query` for improved data fetching and state management, refactoring case study-related logic, and enhancing environment variable handling. These changes streamline the codebase, improve maintainability, and optimize the user experience.

### Integration of `@tanstack/react-query`:

* Added `@tanstack/react-query` as a dependency in `package.json` and updated `pnpm-lock.yaml` to include its resolution and snapshots. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R31) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR69-R71) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2681-R2688) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8978-R8984)
* Created `QueryProvider` in `src/app/(frontend)/query-provider.tsx` to manage query client initialization for both server-side and client-side rendering.
* Updated `Providers` in `src/components/providers.tsx` to include `QueryProvider`, enabling global usage of `@tanstack/react-query`.

### Refactoring case study-related logic:

* Replaced direct CMS service calls with React Query hooks (`useGetCaseStudies` and `useGetCaseStudy`) for fetching case studies. Added these hooks in `src/hooks/use-case-studies.ts` and `src/hooks/use-case-study.ts`. [[1]](diffhunk://#diff-e6285c89a8869ecb4e21aa6e5f8ba27a7b2c8c524dd2b0cd3253a21c12544742R1-R36) [[2]](diffhunk://#diff-85940490f71aeee40b79586d90eb081e565929f953ba3ec1bee66d3169cd475dR1-R24)
* Modified `Header` component in `src/components/header.tsx` to use `useGetCaseStudies` for dynamic case study data and removed `AppSetting` dependency. [[1]](diffhunk://#diff-8387d64f5b5e50e1e386a42e75a377d0d8bf6d40a149697aca42cfeda4c8c206L39-R40) [[2]](diffhunk://#diff-8387d64f5b5e50e1e386a42e75a377d0d8bf6d40a149697aca42cfeda4c8c206L49-R55) [[3]](diffhunk://#diff-8387d64f5b5e50e1e386a42e75a377d0d8bf6d40a149697aca42cfeda4c8c206L192-L193) [[4]](diffhunk://#diff-8387d64f5b5e50e1e386a42e75a377d0d8bf6d40a149697aca42cfeda4c8c206L292-R290) [[5]](diffhunk://#diff-8387d64f5b5e50e1e386a42e75a377d0d8bf6d40a149697aca42cfeda4c8c206L542-R540)
* Updated `sitemap.ts` to use the new `useGetCaseStudies` hook and added a dynamic export to ensure proper CMS access during runtime.

### Environment variable enhancements:

* Added `NEXT_PUBLIC_ENABLE_CASE_STUDIES` environment variable to control case study visibility across the application. Updated `src/env.mjs` to include this variable and its default value. [[1]](diffhunk://#diff-4ed47d4643b7ec88e80c88221860b4c9eca9be1cb89d980ab40ed6087ae47caaR36-R37) [[2]](diffhunk://#diff-4ed47d4643b7ec88e80c88221860b4c9eca9be1cb89d980ab40ed6087ae47caaR57)
* Refactored logic in `case-studies/[slug]/page.tsx` to use the new environment variable for enabling/disabling case studies. ([src/app/(frontend)/case-studies/[slug]/page.tsxL16-R16](diffhunk://#diff-0d41e017a3764c725347e588491bcfcbc22a22d02884d5d0e7310204ca0783d9L16-R16), [src/app/(frontend)/case-studies/[slug]/page.tsxL49-R41](diffhunk://#diff-0d41e017a3764c725347e588491bcfcbc22a22d02884d5d0e7310204ca0783d9L49-R41))

These changes collectively improve the application's scalability, simplify data fetching, and enhance configurability through environment variables.m layout