### PR TITLE
[NCP-N/A] restores toggling study cases from CMS

### DIFF
--- a/src/app/(frontend)/case-studies/[slug]/page.tsx
+++ b/src/app/(frontend)/case-studies/[slug]/page.tsx
@@ -8,12 +8,12 @@ import ScrollDownToDiscover from "@/components/scroll-down-to-discover";
 import Footer from "@/components/footer";
 import LearnMoreButton from "@/components/case-studies/learn-more-button";
 
-import "../page.css"; // Import global styles
+import "../page.css";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
 import { getCaseStudies, getCaseStudy } from "@/cms/service/case-studies";
 import { extractTextFromCaseStudyIntroduction } from "./utils";
-import { env } from "@/env.mjs";
+import { getAppSettings } from "@/cms/service/app-settings";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -22,7 +22,6 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const slug = (await params).slug;
 
-  // fetch post information
   const caseStudy = await getCaseStudy(slug);
   const description = extractTextFromCaseStudyIntroduction(caseStudy?.introduction);
 
@@ -38,7 +37,9 @@ const CaseStudiesPage = async ({ params }: { params: Promise<{ slug: string }> }
 
   const caseStudies = await getCaseStudies();
 
-  const enableCaseStudies = env.NEXT_PUBLIC_ENABLE_CASE_STUDIES === "true";
+  const enableCaseStudies = await getAppSettings().then(
+    (settings) => settings?.enableCaseStudies === "true",
+  );
 
   if (!caseStudy || !enableCaseStudies) {
     notFound();

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -7,6 +7,7 @@ import Analytics from "@/components/analytics";
 import PrivacyBanner from "@/components/privacy-banner";
 import { env } from "@/env.mjs";
 import Header from "@/components/header";
+import { getAppSettings } from "@/cms/service/app-settings";
 
 const circular = localFont({
   src: [
@@ -43,12 +44,14 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const appSettings = await getAppSettings();
+
   return (
     <html lang="en" className={cn("overflow-x-clip scroll-smooth", circular.className)}>
       <body className="overflow-x-clip bg-white text-black">
         <Providers>
           <PrivacyBanner />
-          <Header />
+          <Header appSettings={appSettings} />
           {children}
           <Analytics />
         </Providers>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/components/ui/navigation-menu";
 import useMediaQuery from "@/hooks/use-media-query";
 import useGetCaseStudies from "@/hooks/use-case-studies";
-import { env } from "@/env.mjs";
+import { AppSetting } from "@/payload-types";
 
 const DIALOG_ANIMATION_DURATION = 0.3;
 const HEADER_ANIMATION_DURATION = 0.3;
@@ -47,12 +47,14 @@ const HEADER_VARIANTS = {
   hidden: { y: "-53px" },
 };
 
-const Header = () => {
+const Header = ({ appSettings }: { appSettings?: AppSetting | null }) => {
   const [visible, setVisible] = useState(true);
   const [open, setOpen] = useState(false);
 
-  const { data: caseStudiesData } = useGetCaseStudies();
-  const isCaseStudiesActive = env.NEXT_PUBLIC_ENABLE_CASE_STUDIES === "true";
+  const isCaseStudiesActive = appSettings?.enableCaseStudies === "true";
+  const { data: caseStudiesData } = useGetCaseStudies({
+    enabled: isCaseStudiesActive,
+  });
   // The following state is only used by the desktop navigation (outside of the modal). The value is modified depending
   // on how the user interacts with the menu items (mouse, touch, etc.).
   const [displayIntroductionSubSections, setDisplayIntroductionSubSections] = useState(false);

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -35,8 +35,6 @@ export const env = createEnv({
     NEXT_PUBLIC_GA_TRACKING_ID: z.string().optional(),
     // The Google Tag Manager tracking id
     NEXT_PUBLIC_GTM_TRACKING_ID: z.string().optional(),
-    // Enable case studies on the menu navigation and case studies pages
-    NEXT_PUBLIC_ENABLE_CASE_STUDIES: z.string().default("false"),
   },
   /*
    * Due to how Next.js bundles environment variables on Edge and Client,
@@ -58,6 +56,5 @@ export const env = createEnv({
     EMAIL_DEFAULT_FROM_ADRESS: process.env.EMAIL_DEFAULT_FROM_ADRESS,
     DATABASE_URI: process.env.DATABASE_URI,
     CA_CERTIFICATE: process.env.CA_CERTIFICATE,
-    NEXT_PUBLIC_ENABLE_CASE_STUDIES: process.env.NEXT_PUBLIC_ENABLE_CASE_STUDIES,
   },
 });


### PR DESCRIPTION
This pull request refactors how the "Enable Case Studies" feature is managed by replacing the use of the `NEXT_PUBLIC_ENABLE_CASE_STUDIES` environment variable with a new `getAppSettings` service. It also updates components and pages to accommodate this change and simplifies the environment configuration.

### Refactoring feature toggles:

* `src/app/(frontend)/case-studies/[slug]/page.tsx`: Replaced the `env.NEXT_PUBLIC_ENABLE_CASE_STUDIES` check with a call to `getAppSettings` to determine if case studies are enabled. ([src/app/(frontend)/case-studies/[slug]/page.tsxL11-R16](diffhunk://#diff-0d41e017a3764c725347e588491bcfcbc22a22d02884d5d0e7310204ca0783d9L11-R16), [src/app/(frontend)/case-studies/[slug]/page.tsxL41-R42](diffhunk://#diff-0d41e017a3764c725347e588491bcfcbc22a22d02884d5d0e7310204ca0783d9L41-R42))
* [`src/components/header.tsx`](diffhunk://#diff-8387d64f5b5e50e1e386a42e75a377d0d8bf6d40a149697aca42cfeda4c8c206L40-R40): Updated the `Header` component to receive `appSettings` as a prop and use it to check if case studies are enabled, instead of relying on the `env` object. [[1]](diffhunk://#diff-8387d64f5b5e50e1e386a42e75a377d0d8bf6d40a149697aca42cfeda4c8c206L40-R40) [[2]](diffhunk://#diff-8387d64f5b5e50e1e386a42e75a377d0d8bf6d40a149697aca42cfeda4c8c206L50-R57)

### Updates to layout and settings:

* [`src/app/(frontend)/layout.tsx`](diffhunk://#diff-60f30b12349263a978b99cebf28ed001d6f884d53122bf8175dd09412b4f22c9R10): Added a call to `getAppSettings` in the `RootLayout` component and passed the settings to the `Header` component. [[1]](diffhunk://#diff-60f30b12349263a978b99cebf28ed001d6f884d53122bf8175dd09412b4f22c9R10) [[2]](diffhunk://#diff-60f30b12349263a978b99cebf28ed001d6f884d53122bf8175dd09412b4f22c9R47-R54)

### Environment configuration cleanup:

* [`src/env.mjs`](diffhunk://#diff-4ed47d4643b7ec88e80c88221860b4c9eca9be1cb89d980ab40ed6087ae47caaL38-L39): Removed the `NEXT_PUBLIC_ENABLE_CASE_STUDIES` environment variable and its associated configuration. [[1]](diffhunk://#diff-4ed47d4643b7ec88e80c88221860b4c9eca9be1cb89d980ab40ed6087ae47caaL38-L39) [[2]](diffhunk://#diff-4ed47d4643b7ec88e80c88221860b4c9eca9be1cb89d980ab40ed6087ae47caaL61)